### PR TITLE
Importing standards and linking them to questions

### DIFF
--- a/app/controllers/quizzes/quizzes_controller.rb
+++ b/app/controllers/quizzes/quizzes_controller.rb
@@ -343,7 +343,7 @@ class Quizzes::QuizzesController < ApplicationController
       conditional_release_js_env(@quiz.assignment)
       set_master_course_js_env_data(@quiz, @context)
 
-      @standards = StandardGroup.joins(:standards).merge(Standard.where(:course => @context).order(:code))
+      @standard_groups = StandardGroup.joins(:standards).merge(Standard.where(:course => @context).order(:code))
 
       render :new
     end

--- a/app/controllers/quizzes/quizzes_controller.rb
+++ b/app/controllers/quizzes/quizzes_controller.rb
@@ -343,6 +343,8 @@ class Quizzes::QuizzesController < ApplicationController
       conditional_release_js_env(@quiz.assignment)
       set_master_course_js_env_data(@quiz, @context)
 
+      @standards = Standard.all().order(:code)
+
       render :new
     end
   end

--- a/app/controllers/quizzes/quizzes_controller.rb
+++ b/app/controllers/quizzes/quizzes_controller.rb
@@ -343,7 +343,7 @@ class Quizzes::QuizzesController < ApplicationController
       conditional_release_js_env(@quiz.assignment)
       set_master_course_js_env_data(@quiz, @context)
 
-      @standards = Standard.all().order(:code)
+      @standards = StandardGroup.joins(:standards).merge(Standard.where(:course => @context).order(:code))
 
       render :new
     end

--- a/app/models/assessment_question.rb
+++ b/app/models/assessment_question.rb
@@ -312,7 +312,7 @@ class AssessmentQuestion < ActiveRecord::Base
       :neutral_comments, :question_type, :question_name, :question_text, :answers,
       :formulas, :variables, :answer_tolerance, :formula_decimal_places,
       :matching_answer_incorrect_matches, :matches,
-      :correct_comments_html, :incorrect_comments_html, :neutral_comments_html
+      :correct_comments_html, :incorrect_comments_html, :neutral_comments_html, :standard_id
     )
 
     [

--- a/app/models/assessment_question.rb
+++ b/app/models/assessment_question.rb
@@ -312,7 +312,7 @@ class AssessmentQuestion < ActiveRecord::Base
       :neutral_comments, :question_type, :question_name, :question_text, :answers,
       :formulas, :variables, :answer_tolerance, :formula_decimal_places,
       :matching_answer_incorrect_matches, :matches,
-      :correct_comments_html, :incorrect_comments_html, :neutral_comments_html, :standard_id
+      :correct_comments_html, :incorrect_comments_html, :neutral_comments_html, :standard_group_id
     )
 
     [

--- a/app/models/quizzes/quiz_question/question_data.rb
+++ b/app/models/quizzes/quiz_question/question_data.rb
@@ -80,7 +80,7 @@ class Quizzes::QuizQuestion::QuestionData
     question[:question_text] = fields.sanitize(fields.fetch_with_enforced_length(:question_text, default: I18n.t(:default_question_text, "Question text")))
     question[:answers] = fields.fetch_any(:answers, [])
     question[:text_after_answers] = fields.fetch_any(:text_after_answers)
-    question[:standard_id] = fields.fetch_any(:standard_id)
+    question[:standard_group_id] = fields.fetch_any(:standard_group_id)
 
     if question.is_type?(:calculated)
       question[:formulas] = fields.fetch_any(:formulas, [])

--- a/app/models/quizzes/quiz_question/question_data.rb
+++ b/app/models/quizzes/quiz_question/question_data.rb
@@ -80,6 +80,7 @@ class Quizzes::QuizQuestion::QuestionData
     question[:question_text] = fields.sanitize(fields.fetch_with_enforced_length(:question_text, default: I18n.t(:default_question_text, "Question text")))
     question[:answers] = fields.fetch_any(:answers, [])
     question[:text_after_answers] = fields.fetch_any(:text_after_answers)
+    question[:standard_id] = fields.fetch_any(:standard_id)
 
     if question.is_type?(:calculated)
       question[:formulas] = fields.fetch_any(:formulas, [])

--- a/app/models/standard.rb
+++ b/app/models/standard.rb
@@ -1,0 +1,2 @@
+class Standard < ApplicationRecord
+end

--- a/app/models/standard.rb
+++ b/app/models/standard.rb
@@ -1,2 +1,4 @@
 class Standard < ApplicationRecord
+  belongs_to :standard_group
+  belongs_to :course
 end

--- a/app/models/standard_group.rb
+++ b/app/models/standard_group.rb
@@ -1,0 +1,2 @@
+class StandardGroup < ApplicationRecord
+end

--- a/app/models/standard_group.rb
+++ b/app/models/standard_group.rb
@@ -1,2 +1,3 @@
 class StandardGroup < ApplicationRecord
+  has_many :standards
 end

--- a/app/views/quizzes/quizzes/_display_question.html.erb
+++ b/app/views/quizzes/quizzes/_display_question.html.erb
@@ -121,6 +121,7 @@
         <a href="<%= context_url(@context, :context_quiz_quiz_question_url, @quiz.id, hash_get(question, :id, "{{ id }}")) %>" class="update_question_url">&nbsp;</a>
       <% end %>
       <span class="assessment_question_id"><%= hash_get(question, :assessment_question_id, nbsp) %></span>
+      <span class="standard_id"><%= hash_get(question, :standard_id) %></span>
     </div>
     <div class="text">
       <div class="original_question_text" style="display: none;">

--- a/app/views/quizzes/quizzes/_display_question.html.erb
+++ b/app/views/quizzes/quizzes/_display_question.html.erb
@@ -121,7 +121,7 @@
         <a href="<%= context_url(@context, :context_quiz_quiz_question_url, @quiz.id, hash_get(question, :id, "{{ id }}")) %>" class="update_question_url">&nbsp;</a>
       <% end %>
       <span class="assessment_question_id"><%= hash_get(question, :assessment_question_id, nbsp) %></span>
-      <span class="standard_id"><%= hash_get(question, :standard_id) %></span>
+      <span class="standard_group_id"><%= hash_get(question, :standard_group_id) %></span>
     </div>
     <div class="text">
       <div class="original_question_text" style="display: none;">

--- a/app/views/quizzes/quizzes/_form_question.html.erb
+++ b/app/views/quizzes/quizzes/_form_question.html.erb
@@ -133,6 +133,14 @@
     <div style="text-align: center;">
       <textarea style="width: 90%; height: 120px;" class="question_content" name="question_text"></textarea>
     </div>
+    <label>Standard:</label>
+    <select name="standard_id" class="standard_id">
+        <option value="">None</option>
+        <% @standards.each do |standard| %>
+            <option value="<%= standard[:id] %>"><%= standard[:code] %> - <%= (standard[:description] || '').truncate(30) %></option>
+        <% end %>
+    </select>
+    <div class="clear"></div>
     <b tabindex="0" role="heading" class="answers_header"><%= before_label(:answers, "Answers") %></b>
     <div style="display: none;">
     <select class="answer_selection_type" name="answer_selection_type">

--- a/app/views/quizzes/quizzes/_form_question.html.erb
+++ b/app/views/quizzes/quizzes/_form_question.html.erb
@@ -134,10 +134,10 @@
       <textarea style="width: 90%; height: 120px;" class="question_content" name="question_text"></textarea>
     </div>
     <label>Standard:</label>
-    <select name="standard_id" class="standard_id">
+    <select name="standard_group_id" class="standard_group_id">
         <option value="">None</option>
-        <% @standards.each do |standard| %>
-            <option value="<%= standard[:id] %>"><%= standard[:code] %> - <%= (standard[:description] || '').truncate(30) %></option>
+        <% @standard_groups.each do |standard_group| %>
+            <option value="<%= standard_group[:id] %>"><%= standard_group[:code] %> - <%= (standard_group[:description] || '').truncate(30) %></option>
         <% end %>
     </select>
     <div class="clear"></div>

--- a/db/migrate/20181227204202_create_standards.rb
+++ b/db/migrate/20181227204202_create_standards.rb
@@ -6,8 +6,13 @@ class CreateStandards < ActiveRecord::Migration[5.1]
       t.integer :ext_id
       t.string :code
       t.string :description
+      t.integer :course_id
+      t.integer :school_id
+      t.integer :standard_group_id
 
       t.timestamps
     end
+
+    add_foreign_key :standards, :courses
   end
 end

--- a/db/migrate/20181227204202_create_standards.rb
+++ b/db/migrate/20181227204202_create_standards.rb
@@ -1,0 +1,13 @@
+class CreateStandards < ActiveRecord::Migration[5.1]
+  tag :predeploy
+
+  def change
+    create_table :standards do |t|
+      t.integer :ext_id
+      t.string :code
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190111223002_create_standard_groups.rb
+++ b/db/migrate/20190111223002_create_standard_groups.rb
@@ -9,7 +9,6 @@ class CreateStandardGroups < ActiveRecord::Migration[5.1]
       t.timestamps
     end
 
-    add_column :standards, :standard_group_id, :integer
     add_foreign_key :standards, :standard_groups
   end
 end

--- a/db/migrate/20190111223002_create_standard_groups.rb
+++ b/db/migrate/20190111223002_create_standard_groups.rb
@@ -9,8 +9,6 @@ class CreateStandardGroups < ActiveRecord::Migration[5.1]
       t.timestamps
     end
 
-    add_column :standards, :school_id, :integer
-
     add_column :standards, :standard_group_id, :integer
     add_foreign_key :standards, :standard_groups
   end

--- a/db/migrate/20190111223002_create_standard_groups.rb
+++ b/db/migrate/20190111223002_create_standard_groups.rb
@@ -1,0 +1,17 @@
+class CreateStandardGroups < ActiveRecord::Migration[5.1]
+  tag :predeploy
+
+  def change
+    create_table :standard_groups do |t|
+      t.text :code
+      t.text :description
+
+      t.timestamps
+    end
+
+    add_column :standards, :school_id, :integer
+
+    add_column :standards, :standard_group_id, :integer
+    add_foreign_key :standards, :standard_groups
+  end
+end

--- a/lib/api/v1/quiz_question.rb
+++ b/lib/api/v1/quiz_question.rb
@@ -36,6 +36,7 @@ module Api::V1::QuizQuestion
     question_text
     position
     points_possible
+    standard_id
     correct_comments
     incorrect_comments
     neutral_comments

--- a/lib/api/v1/quiz_question.rb
+++ b/lib/api/v1/quiz_question.rb
@@ -36,7 +36,7 @@ module Api::V1::QuizQuestion
     question_text
     position
     points_possible
-    standard_id
+    standard_group_id
     correct_comments
     incorrect_comments
     neutral_comments

--- a/lib/tasks/read_standards.rake
+++ b/lib/tasks/read_standards.rake
@@ -10,7 +10,6 @@ namespace :standards do
         if course.nil?
             puts 'Unable to find course "' + course_code + '"'
         else
-            school_id = ENV['school']
             # Expects the standard csv to have the headers: ext_id, code, description, school_id
             CSV.foreach(ENV['filepath'], {:headers => true, :header_converters => :symbol}) do |row|
                 standard = Standard.find_by(ext_id: row[:ext_id])

--- a/lib/tasks/read_standards.rake
+++ b/lib/tasks/read_standards.rake
@@ -4,15 +4,36 @@ namespace :standards do
 
     desc 'Import standards data from file'
     task :import => :environment do
-        CSV.foreach(ENV['filepath'], {:headers => true, :header_converters => :symbol}) do |row|
-            standard = Standard.find_by(ext_id: row[:ext_id])
-            if standard.nil?
-                standard = Standard.new
-                standard.ext_id = row[:ext_id]
+        course_code = ENV['course']
+        course = Course.find_by(course_code: course_code)
+
+        if course.nil?
+            puts 'Unable to find course "' + course_code + '"'
+        else
+            school_id = ENV['school']
+            # Expects the standard csv to have the headers: ext_id, code, description, school_id
+            CSV.foreach(ENV['filepath'], {:headers => true, :header_converters => :symbol}) do |row|
+                standard = Standard.find_by(ext_id: row[:ext_id])
+                if standard.nil?
+                    standard = Standard.new
+                    standard.ext_id = row[:ext_id]
+                end
+                standard.school_id = row[:school_id]
+                standard.code = row[:code]
+                standard.description = row[:description]
+                standard.course = course
+
+                group = StandardGroup.find_by(code: standard.code, description: standard.description)
+                if group.nil?
+                    group = StandardGroup.new
+                    group.code = standard.code
+                    group.description = standard.description
+                    group.save
+                end
+
+                standard.standard_group = group
+                standard.save
             end
-            standard.code = row[:code]
-            standard.description = row[:description]
-            standard.save
         end
     end
 end

--- a/lib/tasks/read_standards.rake
+++ b/lib/tasks/read_standards.rake
@@ -1,0 +1,18 @@
+require 'csv'
+
+namespace :standards do
+
+    desc 'Import standards data from file'
+    task :import => :environment do
+        CSV.foreach(ENV['filepath'], {:headers => true, :header_converters => :symbol}) do |row|
+            standard = Standard.find_by(ext_id: row[:ext_id])
+            if standard.nil?
+                standard = Standard.new
+                standard.ext_id = row[:ext_id]
+            end
+            standard.code = row[:code]
+            standard.description = row[:description]
+            standard.save
+        end
+    end
+end

--- a/public/javascripts/quizzes.js
+++ b/public/javascripts/quizzes.js
@@ -1385,7 +1385,7 @@ const lockedItems = lockManager.isChildContent() ? lockManager.getItemLocks() : 
     $list.each(function(i) {
       var $question = $(this);
       var questionData = $question.getTemplateData({
-        textValues: ['question_name', 'question_points', 'question_type', 'answer_selection_type', 'assessment_question_id', 'correct_comments', 'incorrect_comments', 'neutral_comments', 'matching_answer_incorrect_matches', 'equation_combinations', 'equation_formulas', 'regrade_option', 'standard_id'],
+        textValues: ['question_name', 'question_points', 'question_type', 'answer_selection_type', 'assessment_question_id', 'correct_comments', 'incorrect_comments', 'neutral_comments', 'matching_answer_incorrect_matches', 'equation_combinations', 'equation_formulas', 'regrade_option', 'standard_group_id'],
         htmlValues: ['question_text', 'text_before_answers', 'text_after_answers', 'correct_comments_html', 'incorrect_comments_html', 'neutral_comments_html']
       });
       questionData = $.extend(questionData, $question.find(".original_question_text").getFormData());
@@ -1498,7 +1498,7 @@ const lockedItems = lockManager.isChildContent() ? lockManager.getItemLocks() : 
       q.variables = question.variables;
       q.answer_tolerance = question.answer_tolerance;
       q.formula_decimal_places = question.formula_decimal_places;
-      q.standard_id = question.standard_id;
+      q.standard_id = question.standard_group_id;
 
       q.answers = question.answers;
       data.questions.push(q);
@@ -2096,7 +2096,7 @@ const lockedItems = lockManager.isChildContent() ? lockManager.getItemLocks() : 
       var question = $question.getTemplateData({
         textValues: ['question_type', 'correct_comments', 'incorrect_comments', 'neutral_comments',
                      'question_name', 'question_points', 'answer_selection_type', 'blank_id',
-                     'matching_answer_incorrect_matches', 'regrade_option', 'regrade_disabled', 'standard_id'],
+                     'matching_answer_incorrect_matches', 'regrade_option', 'regrade_disabled', 'standard_group_id'],
         htmlValues: ['question_text', 'correct_comments_html', 'incorrect_comments_html', 'neutral_comments_html']
       });
       question.question_text = $question.find("textarea[name='question_text']").val();
@@ -2990,7 +2990,7 @@ const lockedItems = lockManager.isChildContent() ? lockManager.getItemLocks() : 
       var questionData = $question.getFormData({
         textValues: ['question_type', 'question_name', 'question_points', 'correct_comments', 'incorrect_comments', 'neutral_comments',
           'question_text', 'answer_selection_type', 'text_after_answers', 'matching_answer_incorrect_matches',
-          'regrade_option', 'regrade_disabled', 'standard_id'],
+          'regrade_option', 'regrade_disabled', 'standard_group_id'],
         htmlValues: ['correct_comments_html', 'incorrect_comments_html', 'neutral_comments_html']
       });
 

--- a/public/javascripts/quizzes.js
+++ b/public/javascripts/quizzes.js
@@ -1385,7 +1385,7 @@ const lockedItems = lockManager.isChildContent() ? lockManager.getItemLocks() : 
     $list.each(function(i) {
       var $question = $(this);
       var questionData = $question.getTemplateData({
-        textValues: ['question_name', 'question_points', 'question_type', 'answer_selection_type', 'assessment_question_id', 'correct_comments', 'incorrect_comments', 'neutral_comments', 'matching_answer_incorrect_matches', 'equation_combinations', 'equation_formulas', 'regrade_option'],
+        textValues: ['question_name', 'question_points', 'question_type', 'answer_selection_type', 'assessment_question_id', 'correct_comments', 'incorrect_comments', 'neutral_comments', 'matching_answer_incorrect_matches', 'equation_combinations', 'equation_formulas', 'regrade_option', 'standard_id'],
         htmlValues: ['question_text', 'text_before_answers', 'text_after_answers', 'correct_comments_html', 'incorrect_comments_html', 'neutral_comments_html']
       });
       questionData = $.extend(questionData, $question.find(".original_question_text").getFormData());
@@ -1498,6 +1498,7 @@ const lockedItems = lockManager.isChildContent() ? lockManager.getItemLocks() : 
       q.variables = question.variables;
       q.answer_tolerance = question.answer_tolerance;
       q.formula_decimal_places = question.formula_decimal_places;
+      q.standard_id = question.standard_id;
 
       q.answers = question.answers;
       data.questions.push(q);
@@ -2095,7 +2096,7 @@ const lockedItems = lockManager.isChildContent() ? lockManager.getItemLocks() : 
       var question = $question.getTemplateData({
         textValues: ['question_type', 'correct_comments', 'incorrect_comments', 'neutral_comments',
                      'question_name', 'question_points', 'answer_selection_type', 'blank_id',
-                     'matching_answer_incorrect_matches', 'regrade_option', 'regrade_disabled'],
+                     'matching_answer_incorrect_matches', 'regrade_option', 'regrade_disabled', 'standard_id'],
         htmlValues: ['question_text', 'correct_comments_html', 'incorrect_comments_html', 'neutral_comments_html']
       });
       question.question_text = $question.find("textarea[name='question_text']").val();
@@ -2989,7 +2990,7 @@ const lockedItems = lockManager.isChildContent() ? lockManager.getItemLocks() : 
       var questionData = $question.getFormData({
         textValues: ['question_type', 'question_name', 'question_points', 'correct_comments', 'incorrect_comments', 'neutral_comments',
           'question_text', 'answer_selection_type', 'text_after_answers', 'matching_answer_incorrect_matches',
-          'regrade_option', 'regrade_disabled'],
+          'regrade_option', 'regrade_disabled', 'standard_id'],
         htmlValues: ['correct_comments_html', 'incorrect_comments_html', 'neutral_comments_html']
       });
 

--- a/public/javascripts/quizzes.js
+++ b/public/javascripts/quizzes.js
@@ -1498,7 +1498,7 @@ const lockedItems = lockManager.isChildContent() ? lockManager.getItemLocks() : 
       q.variables = question.variables;
       q.answer_tolerance = question.answer_tolerance;
       q.formula_decimal_places = question.formula_decimal_places;
-      q.standard_id = question.standard_group_id;
+      q.standard_group_id = question.standard_group_id;
 
       q.answers = question.answers;
       data.questions.push(q);


### PR DESCRIPTION
### Description
We're going to start doing weekly quizzes in Canvas, and we do data analysis based on standards. These changes give us a way to upload standards in Canvas and link questions to them. A big part of the consideration in the behavior of the code is how SchoolRunner treats standards. Each of our middle school courses in SchoolRunner has it's own list of standards, even if they're duplicated. For an example, we use a standard with the code 5.R.F.4 but track five different instances of it because it exists five times in SR (once for each Lit5 course at LCA, RP, NP, SP, and NACS).

So when creating a question on a quiz for Lit5 in canvas, we select the standard group. Later on, when syncing quizzes from Canvas to SR, we'll use the standard from the group that belongs to the school that the assessment will be associated with in SR.

### Test
1. Run `bundle exec rails db:migrate` to update your db schema with the changes in the migration files.
1. Make a CSV file that contains some standards. Set the headers to be ext_id, code, description, and school_id. The values of each column can be whatever, but in prod ext_id will mean the SchoolRunner id for that standard. You can make two standards with the same code and description but different ext_id's and school_id's to simulate what a standard_group would look like with more than one standard.
1. Run `bundle exec rake standards:import filepath=xxxxx course=xxxxx` where the file path is the path to the standards CSV file you created and the course argument is the code name of the course you want to add the standards to.
1. Run `bundle exec rake js:webpack_development` to update your local build with the changes in the js file.
1. Edit a quiz in the course you added the standards to and verify that, when editing a question, you can select a standard for that question and have that standard selection save and reload when you edit the question again later.