### PR TITLE
Adding awareness of section-periods to canvas

### DIFF
--- a/db/migrate/20190109210238_add_section_period_ids_to_course_section.rb
+++ b/db/migrate/20190109210238_add_section_period_ids_to_course_section.rb
@@ -1,0 +1,7 @@
+class AddSectionPeriodIdsToCourseSection < ActiveRecord::Migration[5.1]
+  tag :predeploy
+
+  def change
+    add_column :course_sections, :section_period_ids, :text
+  end
+end

--- a/lib/sis/csv/section_importer.rb
+++ b/lib/sis/csv/section_importer.rb
@@ -44,7 +44,7 @@ module SIS
             end
 
             begin
-              importer.add_section(row['section_id'], row['course_id'], row['name'], row['status'], start_date, end_date, row['integration_id'])
+              importer.add_section(row['section_id'], row['course_id'], row['name'], row['status'], start_date, end_date, row['integration_id'], row['section_period_ids'])
             rescue ImportError => e
               SisBatch.add_error(csv, e.to_s, sis_batch: @batch, row: row['lineno'], row_info: row)
             end

--- a/lib/sis/section_importer.rb
+++ b/lib/sis/section_importer.rb
@@ -71,7 +71,7 @@ module SIS
         @deleted_section_ids = Set.new
       end
 
-      def add_section(section_id, course_id, name, status, start_date=nil, end_date=nil, integration_id=nil)
+      def add_section(section_id, course_id, name, status, start_date=nil, end_date=nil, integration_id=nil, section_period_ids=nil)
         @logger.debug("Processing Section #{[section_id, course_id, name, status, start_date, end_date].inspect}")
 
         raise ImportError, "No section_id given for a section in course #{course_id}" if section_id.blank?
@@ -91,6 +91,7 @@ module SIS
 
         # only update the name on new records, and ones that haven't been changed since the last sis import
         section.name = name if section.new_record? || !section.stuck_sis_fields.include?(:name)
+        section.section_period_ids = section_period_ids
 
         # update the course id if necessary
         if section.course_id != course.id


### PR DESCRIPTION
### Description
Canvas is only aware of sections within a course, it doesn't have the sense of sections-periods that SchoolRunner does. When exporting assessments to SR, we'll need to be able to specify the section period ids that the assessments belong to. These changes add functionality to the section importing code so that we can provide section-period id's for each section we upload to canvas.

To simplify this process I have the database holding the section-period id's as a comma delimited string. Not the greatest if we ever choose to do anything else with them, but at the moment it's the simplest. Sorry for whoever might need to work with them in the future.

### Testing
- In your canvas root directory, run `bundle exec rails db:migrate` to update your database schema with the new migration file. Restart your canvas server and delayed jobs script to get everything up to date with the new code.
- Click on Admin in the menu bar and then the Republic account.
- Courses will be the default section, there should be an SIS Import section. I think I had to enable it, let me know if you don't see it.
- In the SIS Import section upload a CSV file that defines a section for a course and some section-period id's for that section. You'll need to set up a course with a sis id number that you can reference in the file. Let me know when you're here and we can set that up together.
- In the database, verify that the section is created for the course and has the given section period ids.
