### PR TITLE
Authentication fixes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -628,7 +628,7 @@ class ApplicationController < ActionController::Base
       format.any(:html, :pdf) do
         return unless fix_ms_office_redirects
         store_location
-        return redirect_to login_url(params.permit(:authentication_provider)) if !@files_domain && !@current_user
+        return redirect_to auth_url(params.permit(:authentication_provider)) if !@files_domain && !@current_user
 
         if @context.is_a?(Course) && @context_enrollment
           if @context_enrollment.inactive?

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1409,7 +1409,7 @@ class CoursesController < ApplicationController
       session[:return_to] = course_url(@context.id)
       flash[:notice] = t('notices.login_to_accept', "You'll need to log in before you can accept the enrollment.")
       return redirect_to login_url(:force_login => 1) if @current_user
-      redirect_to login_url
+      redirect_to auth_url
     else
       # defer to CommunicationChannelsController#confirm for the logic of merging users
       redirect_to registration_confirmation_path(enrollment.user.email_channel.confirmation_code, :enrollment => enrollment.uuid)

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -104,7 +104,7 @@ class LoginController < ApplicationController
       redirect = aac.try(:user_logout_redirect, self, @current_user)
     end
 
-    redirect ||= login_url
+    redirect ||= auth_url
     logout_current_user
 
     flash[:logged_out] = true

--- a/app/models/pseudonym.rb
+++ b/app/models/pseudonym.rb
@@ -141,8 +141,7 @@ class Pseudonym < ActiveRecord::Base
 
   def self.for_auth_configuration(unique_id, aac)
     auth_id = aac.try(:auth_provider_filter)
-    active.by_unique_id(unique_id).where(authentication_provider_id: auth_id).
-      order("authentication_provider_id NULLS LAST").take
+    active.by_unique_id(unique_id).order("authentication_provider_id NULLS LAST").take
   end
 
   def set_password_changed


### PR DESCRIPTION
### Description
Found a few more references to the login_url method/route. Also altering the code to allow a pseudonym to be recognized regardless of the authentication it's specified for. This lets us manually create logins for students that can be used to sign in with Google.

### Testing
#### Setup
- Configure your instance of Canvas to allow for Google authentication by going to the Republic account, selecting Authentication, and use the dropdown on the right to select Google.
- Give `299091934967-23le2fbtpmcd4b9etiml28p51783gni5.apps.googleusercontent.com` as the client id and `UVMxK21UfECzjiXp2L19nle7` as the client secret.
#### Seeing what happens without these changes
- Before checking out the code, have a user set up with a login username of an email set up with a Google account (with the email as the unique_id of the users pseudonym).
- Try to use the Google login with the account that has been set up and see that the login fails.
#### Verifying these changes
- Checkout the code and try the same thing and see that the login works with these changes.