### PR TITLE
Fixes made while working with prod

### DIFF
--- a/app/views/quizzes/quizzes/_form_question.html.erb
+++ b/app/views/quizzes/quizzes/_form_question.html.erb
@@ -136,7 +136,7 @@
     <label>Standard:</label>
     <select name="standard_group_id" class="standard_group_id">
         <option value="">None</option>
-        <% @standard_groups.each do |standard_group| %>
+        <% Array(@standard_groups).each do |standard_group| %>
             <option value="<%= standard_group[:id] %>"><%= standard_group[:code] %> - <%= (standard_group[:description] || '').truncate(30) %></option>
         <% end %>
     </select>

--- a/db/migrate/20190131153841_add_sr_id_to_course.rb
+++ b/db/migrate/20190131153841_add_sr_id_to_course.rb
@@ -1,0 +1,7 @@
+class AddSrIdToCourse < ActiveRecord::Migration[5.1]
+  tag :predeploy
+  
+  def change
+    add_column :courses, :sr_id, :integer
+  end
+end

--- a/lib/tasks/sr_export.rake
+++ b/lib/tasks/sr_export.rake
@@ -39,7 +39,7 @@ def compile_submission_answers(submission, quiz)
         {
             :question_number => index + 1,
             :answer => answer,
-            :points => question_answer ? question_answer[:points] : 0
+            :points => question_answer ? question_answer[:points] : ''
         }
     }
 end

--- a/lib/tasks/sr_export.rake
+++ b/lib/tasks/sr_export.rake
@@ -22,11 +22,12 @@ def compile_submission_answers(submission, quiz)
     quiz.root_entries.each_with_index.map { |question, index|
         answer = ''
         question_answer = submission[:submission_data].find {|answer| answer[:question_id] == question[:id]}
-        if question_answer
+        answered_question = submission[:quiz_data][index]
+        if question_answer && question_answer.key?(:answer_id)
             if question[:question_type] == 'multiple_choice_question'
-                answer = char_from_answer_index(question[:answers].index {|answer| answer[:id] == question_answer[:answer_id] })
+                answer = char_from_answer_index(answered_question[:answers].index {|answer| answer[:id] == question_answer[:answer_id] })
             elsif question[:question_type] == 'multiple_answers_question'
-                answer = question[:answers].each_with_index.map { |answer, index|
+                answer = answered_question[:answers].each_with_index.map { |answer, index|
                     if question_answer && question_answer[('answer_' + answer[:id].to_s).to_sym] == "1"
                         char_from_answer_index(index)
                     else
@@ -53,7 +54,7 @@ def compile_student_work(submissions, quiz)
                 :student => {
                     :external_id => student_sis_pseudonym.sis_user_id
                 },
-                :score_override => submission.kept_score,
+                :score_override => '',
                 :submission_date => submission.finished_at.strftime('%Y-%m-%d'),
                 :answers => compile_submission_answers(submission, quiz)
             })
@@ -82,7 +83,7 @@ def quiz_sr_api_data(quiz)
             },
             :students_active => 1,
             :course => {
-                :course_id => quiz.course.sis_source_id
+                :course_id => quiz.course.sr_id
             },
             :section_periods => section_period_ids,
             :assessment_type => {

--- a/lib/tasks/sr_export.rake
+++ b/lib/tasks/sr_export.rake
@@ -39,7 +39,7 @@ def compile_submission_answers(submission, quiz)
         {
             :question_number => index + 1,
             :answer => answer,
-            :points => question_answer ? question_answer[:points] : ''
+            :points => question_answer ? question_answer[:points] : 0
         }
     }
 end


### PR DESCRIPTION
### Description
There were a few things that needed to be fixed to get all the Canvas/SR changes to work well.
#### Courses with no standards
If a course in Canvas didn't have any standards linked to it then `@standard_groups` on line 139 of _form_questions.html.erb would be Nil, and calling any methods on a Nil object throws an error. So I cast it to an array and it just ends up being an empty array if there's nothing there.
#### SR ID's for Courses
Canvas's course model has an `sis_source_id` field that I was imagining we could use to hold SR's id for the course for reference when uploading the quizzes. SR has each teacher linked up to the same course and only distinguishes courses by grade level (Literacy 5, Literacy 6, ...) within a school, where we have a course instance for each teacher in Canvas. So two separate Canvas courses would need to use the same SR id if they're both for the same school and 5th grade. Currently canvas has restrictions set up that disable two courses having the same `sis_source_id` set up. Rather than try to disable any uniqueness checks and potentially cause another issue to arise, I went ahead and added a `sr_id` column to courses. Ideally there will be a UI component at some point so we're not setting it directly in the database, but for now that's what we've got.
#### Not setting score override
When uploading student data for an assessment, SR allows for setting the `score_override` field but I didn't realize SR was treating it as a percent. To simplify the process I'm just leaving things as the raw point values and not trying to account for the fudge points that Canvas allows.
#### Question answers
Canvas has a QuizQuestion model, but doesn't store question answers individually in the database. Instead it stores the answers as a hash in the QuizQuestion records. It does something very similar when a student submits an answer to a question. If a quiz changes for some reason (in the case when I found this, it was probably when trying to set the standard on the quizzes) the answers on the questions for the quiz can receive new ids. So when looking at a student's submission, the answer id for what they selected may no longer actually be a part of the quiz question. Good news is that when students make a submission, a record of the quiz questions at the time is stored with the submission. So instead of trying to find the data from the question off the current quiz instance, the code now looks for the order of the question options as it was when the student made the submission.

This also makes a check that a student did actually answer the question. If they didn't then it leaves the score as 0.
### Testing
- Verify that quizzes in courses can be edited when there are no standards linked to that course.
- Verify that when syncing quizzes to SR, the sr_id value is used rather than the sis_source_id. Also check that a student's submission in the export has the score override set as an empty string.
- With a student submission on a quiz that's part of a blueprint template setup (quiz that has been exported from a blueprint course to the course where it was taken) update the blueprint quiz and resync to the other course. Verify in the database that the question's answer ids no longer match between the quiz and the student's submission. Run the SR export and verify that the student's submission still gets the right option sent to SR (A, B, ...).
