### PR TITLE
Exporting standard group ids from blueprint quizzes

### DIFF
--- a/app/models/importers/quiz_question_importer.rb
+++ b/app/models/importers/quiz_question_importer.rb
@@ -31,6 +31,7 @@ module Importers
       hash[:position] = position
       hash[:points_possible] = qq_hash[:points_possible] if qq_hash[:points_possible]
       hash[:points_possible] = 0 if hash[:points_possible].to_f < 0
+      hash[:standard_group_id] = aq_hash[:standard_group_id]
 
       mig_id = qq_hash['quiz_question_migration_id'] || qq_hash['migration_id']
 

--- a/gems/plugins/qti_exporter/lib/qti/assessment_item_converter.rb
+++ b/gems/plugins/qti_exporter/lib/qti/assessment_item_converter.rb
@@ -182,6 +182,9 @@ class AssessmentItemConverter
       if score = get_node_att(meta, 'instructureField[name=points_possible]', 'value')
         @question[:points_possible] = [score.to_f, 0.0].max
       end
+      if standard_group_id = get_node_att(meta, 'instructureField[name=standard_group_id]', 'value')
+        @question[:standard_group_id] = standard_group_id
+      end
       if ref = get_node_att(meta, 'instructureField[name=assessment_question_identifierref]', 'value')
         @question[:assessment_question_migration_id] = ref
       end

--- a/lib/cc/qti/qti_items.rb
+++ b/lib/cc/qti/qti_items.rb
@@ -109,12 +109,14 @@ module CC
             meta_node.qtimetadata do |qm_node|
               if for_cc
                 meta_field(qm_node, 'cc_profile', CC_TYPE_PROFILES[question['question_type']])
+                meta_field(qm_node, 'standard_group_id', question['standard_group_id'])
                 if question['question_type'] == 'essay_question'
                   meta_field(qm_node, 'qmd_computerscored', 'No')
                 end
               else
                 meta_field(qm_node, 'question_type', question['question_type'])
                 meta_field(qm_node, 'points_possible', question['points_possible'])
+                meta_field(qm_node, 'standard_group_id', question['standard_group_id'])
                 if question[:is_quiz_question]
                   meta_field(qm_node, 'assessment_question_identifierref', aq_mig_id(question))
                 end


### PR DESCRIPTION
### Description
When exporting from Canvas to SR, we use the quiz data that exists in the instance of the course for a specific teacher. And when defining the quizzes (and setting their standards) we work with the blueprint course. The standard group is stored in a hash on the question, but that wasn't being exported from the blueprint courses to the individual courses.

These changes replicate the process of exporting and importing other fields for quiz question data to pass the standard group ids along as well.

### Testing
- Have a pair of courses set up, one as a blueprint course to the other.
- Have a standard group set up on the blueprint course.
- Create (or already have) a quiz in the blueprint course and set a standard group on a question in the quiz.
- Verify that the quiz question in the associated course updates with changes to the standard group on the question in the blueprint course when syncing. The UI won't show the standard group in the drop down for the associated course, so you'll need to use the UI to find the ID for the quiz question and then see the standard group field in the question's question_data field in the database.