### PR TITLE
Changing more auth_url endpoints

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -524,7 +524,7 @@ class ApplicationController < ActionController::Base
       return render plain: "Please finish logging in", status: 403 if request.xhr?
 
       reset_session
-      redirect_to login_url
+      redirect_to auth_url
     end
   end
 
@@ -581,7 +581,7 @@ class ApplicationController < ActionController::Base
     if session[:used_remember_me_token]
       flash[:warning] = t "#application.warnings.please_log_in", "For security purposes, please enter your password to continue"
       store_location
-      redirect_to login_url
+      redirect_to auth_url
       return false
     end
     true
@@ -661,7 +661,7 @@ class ApplicationController < ActionController::Base
     if !@context
       if @context_is_current_user
         store_location
-        redirect_to login_url
+        redirect_to auth_url
       elsif params[:context_id]
         raise ActiveRecord::RecordNotFound.new("Cannot find #{params[:context_type] || 'Context'} for ID: #{params[:context_id]}")
       else
@@ -1366,7 +1366,7 @@ class ApplicationController < ActionController::Base
       message = exception.xhr_message if exception.respond_to?(:xhr_message)
       render_xhr_exception(error, message, status, status_code)
     elsif exception.is_a?(ActionController::InvalidAuthenticityToken) && cookies[:_csrf_token].blank?
-      redirect_to login_url(needs_cookies: '1')
+      redirect_to auth_url(needs_cookies: '1')
       reset_session
       return
     else

--- a/app/controllers/login/oauth2_controller.rb
+++ b/app/controllers/login/oauth2_controller.rb
@@ -47,7 +47,7 @@ class Login::Oauth2Controller < Login::OauthBaseController
   def validate_request
     if params[:error_description]
       flash[:delegated_message] = Sanitize.clean(params[:error_description])
-      redirect_to login_url
+      redirect_to auth_url
       return false
     end
 
@@ -57,7 +57,7 @@ class Login::Oauth2Controller < Login::OauthBaseController
       end
     rescue Canvas::Security::TokenExpired
       flash[:delegated_message] = t("It took too long to login. Please try again")
-      redirect_to login_url
+      redirect_to auth_url
       return false
     end
 

--- a/app/controllers/login/oauth_base_controller.rb
+++ b/app/controllers/login/oauth_base_controller.rb
@@ -57,13 +57,13 @@ class Login::OauthBaseController < ApplicationController
                            account_id: @aac.global_account_id)
     flash[:delegated_message] = t("There was a problem logging in at %{institution}",
                                   institution: @domain_root_account.display_name)
-    redirect_to login_url
+    redirect_to auth_url
     false
   end
 
   def find_pseudonym(unique_ids, provider_attributes = {})
     if unique_ids.nil?
-      unknown_user_url = @domain_root_account.unknown_user_url.presence || login_url
+      unknown_user_url = @domain_root_account.unknown_user_url.presence || auth_url
       logger.warn "Received OAuth2 login with no unique_id"
       flash[:delegated_message] =
           t("Authentication with %{provider} was successful, but no unique ID for logging in to Canvas was provided.",

--- a/app/messages/forgot_password.email.erb
+++ b/app/messages/forgot_password.email.erb
@@ -1,5 +1,5 @@
 <% define_content :link do %>
-  <%= login_url %>
+  <%= auth_url %>
 <% end %>
 
 <% define_content :subject do %>

--- a/app/messages/forgot_password.email.html.erb
+++ b/app/messages/forgot_password.email.html.erb
@@ -1,5 +1,5 @@
 <% define_content :link do %>
-  <%= login_url %>
+  <%= auth_url %>
 <% end %>
 
 <% define_content :subject do %>


### PR DESCRIPTION
Craig tried to use the 'Forgot Password' link, but it crashed on the login_url when trying to send him an email. Looking at the error reports shows that there are more errors happening with the login_url still being some places. This PR changes the references that seem to be the cause of the crashes shown in the error reports.

I've only been able to test that the 'Forgot Password' crash doesn't happen anymore. I'm not sure what lead to the other crashes, but if these keep those errors from recurring we'll know they worked.