### PR TITLE
Section Period Ids to School Runner

### DIFF
--- a/Gemfile.d/development.rb
+++ b/Gemfile.d/development.rb
@@ -25,5 +25,7 @@ group :development do
   # Set this option in your dev environment to disable.
   unless ENV['DISABLE_RUBY_DEBUGGING']
     gem 'byebug', '10.0.2', platform: :mri
+    gem 'ruby-debug-ide'
+    gem 'debase'
   end
 end

--- a/lib/tasks/sr_export.rake
+++ b/lib/tasks/sr_export.rake
@@ -76,8 +76,10 @@ def quiz_sr_api_data(quiz)
     }.map { |section|
         puts "map " + section.inspect
         section[:section_period_ids]
-    }.join(',')
-    
+    }.join(',').split(',').map { |section_period|
+        section_period.to_i
+    }
+
     puts('SECTION PERIOD IDS: ', section_period_ids.to_s)
 
     {

--- a/lib/tasks/sr_export.rake
+++ b/lib/tasks/sr_export.rake
@@ -69,19 +69,15 @@ def quiz_sr_api_data(quiz)
     sis_pseudonym = SisPseudonym.for(teacher, LoadAccount.default_domain_root_account, type: :implicit, require_sis: false)
     sr_id = sis_pseudonym.ext_id
     school_id = sis_pseudonym.school_id
-    # section_period_ids = quiz.course.course_sections.each.map { |section|
-    section_period_ids = quiz.course.course_sections.each.select { |section|
-        puts "select " + section.inspect
-        section[:section_period_ids] != '' && section[:section_period_ids] != nil
+    section_period_ids = quiz.course.course_sections.each.reject { |section|
+        # !(section[:section_period_ids].empty? && section[:section_period_ids].nil?)
+        section[:section_period_ids].blank?
     }.map { |section|
-        puts "map " + section.inspect
         section[:section_period_ids]
     }.join(',').split(',').map { |section_period|
         section_period.to_i
     }
-
-    puts('SECTION PERIOD IDS: ', section_period_ids.to_s)
-
+    puts('SECTION PERIOD IDS', section_period_ids.to_s)
     {
         :assessment_definition => {
             :external_assessment_id => 'CANVAS_' + quiz.id.to_s,
@@ -130,7 +126,7 @@ namespace :sr do
 
         for quiz in quizzes do
             quiz_data = quiz_sr_api_data(quiz)
-
+            puts('QUIZ DATA', quiz_data.inspect)
             response = HTTParty.post(ENV['SR_URL'] + "/api/v1/assessments/import",
                                     :body => {
                                         :assessment_data => quiz_data.to_json

--- a/lib/tasks/sr_export.rake
+++ b/lib/tasks/sr_export.rake
@@ -70,14 +70,13 @@ def quiz_sr_api_data(quiz)
     sr_id = sis_pseudonym.ext_id
     school_id = sis_pseudonym.school_id
     section_period_ids = quiz.course.course_sections.each.reject { |section|
-        # !(section[:section_period_ids].empty? && section[:section_period_ids].nil?)
         section[:section_period_ids].blank?
     }.map { |section|
         section[:section_period_ids]
     }.join(',').split(',').map { |section_period|
         section_period.to_i
     }
-    puts('SECTION PERIOD IDS', section_period_ids.to_s)
+
     {
         :assessment_definition => {
             :external_assessment_id => 'CANVAS_' + quiz.id.to_s,
@@ -126,7 +125,7 @@ namespace :sr do
 
         for quiz in quizzes do
             quiz_data = quiz_sr_api_data(quiz)
-            puts('QUIZ DATA', quiz_data.inspect)
+
             response = HTTParty.post(ENV['SR_URL'] + "/api/v1/assessments/import",
                                     :body => {
                                         :assessment_data => quiz_data.to_json

--- a/lib/tasks/sr_export.rake
+++ b/lib/tasks/sr_export.rake
@@ -69,9 +69,16 @@ def quiz_sr_api_data(quiz)
     sis_pseudonym = SisPseudonym.for(teacher, LoadAccount.default_domain_root_account, type: :implicit, require_sis: false)
     sr_id = sis_pseudonym.ext_id
     school_id = sis_pseudonym.school_id
-    section_period_ids = quiz.course.course_sections.each.map { |section|
+    # section_period_ids = quiz.course.course_sections.each.map { |section|
+    section_period_ids = quiz.course.course_sections.each.select { |section|
+        puts "select " + section.inspect
+        section[:section_period_ids] != '' && section[:section_period_ids] != nil
+    }.map { |section|
+        puts "map " + section.inspect
         section[:section_period_ids]
     }.join(',')
+    
+    puts('SECTION PERIOD IDS: ', section_period_ids.to_s)
 
     {
         :assessment_definition => {
@@ -141,11 +148,11 @@ namespace :sr do
             end
         end
 
-        path_response = HTTParty.post(ENV['PATH_URL'] + "/dat-assessments/assessment-groups/configure",
-                                      :body => {
-                                          'groups' => assessment_groups
-                                      }.to_json,
-                                      :headers => { 'Content-Type' => 'application/json' })
+        # path_response = HTTParty.post(ENV['PATH_URL'] + "/dat-assessments/assessment-groups/configure",
+        #                               :body => {
+        #                                   'groups' => assessment_groups
+        #                               }.to_json,
+        #                               :headers => { 'Content-Type' => 'application/json' })
 
         puts "Export complete"
     end


### PR DESCRIPTION
## Description of Proposed Changes
Up until now, our database did not have any `section_course_ids` set on the `course_sections` table which prevented School Runner from setting the section period ids for active course sections for a teacher. Prior to these changes, the sections part of the following image was blank and required us to manually set the section periods.

<img width="902" alt="screen shot 2019-03-05 at 4 03 52 pm" src="https://user-images.githubusercontent.com/37703659/53840729-7bec3a00-3f60-11e9-98e7-ec4364ab2347.png">

We manually updated our database with active section period ids; however, while the sync was sending a string of comma separated section period ids, School Runner still wouldn't recognize these ids or use them.  Since SR uses section period ids from PATH successfully, we used Wireshark to compare data being sent from PATH vs Canvas.  We learned PATH is sending an array of comma separated integers.

Structure from CANVAS:
![canvas ss](https://user-images.githubusercontent.com/37703659/53840893-ff0d9000-3f60-11e9-91f0-95567a9276ff.png)

Structure from PATH: 
![screen shot 2019-03-04 at 12 07 13 pm](https://user-images.githubusercontent.com/37703659/53840902-05037100-3f61-11e9-8f33-de593e5a8454.png)

Once we changed the data structure being sent from Canvas, SR accepted the array of integers.

## Steps to Test

```sh
git fetch --all
git checkout rc-section-comma-fix
```
* This code is already running in production
1. SSH into the Dream Host server
1. `cd ../canvas_user/canvas_sail/lib/tasks`
1. `Sudo nano sr_export.rake`
1. Go to ~line 128 and comment out all the previous assessments
1. Uncomment ~line 133 to just sync a single assessment.
1. Save your changes
1. `su canvas_user` and enter the password
1. Run the School Runner Explort: `RAILS_ENV=production bundle exec rake sr:export`
1. Look to see that the section period ids are being sent as an array of integers like this image:
    <img width="497" alt="screen shot 2019-03-05 at 4 44 27 pm" src="https://user-images.githubusercontent.com/37703659/53842812-2adf4480-3f66-11e9-9ef3-930546a7e654.png">
1. Look for section period ids array in Quiz Data as well:
    <img width="495" alt="screen shot 2019-03-05 at 4 44 50 pm" src="https://user-images.githubusercontent.com/37703659/53842855-45192280-3f66-11e9-9278-f8de02232e66.png">
1. Once the sync is completed successfully, find your assessment in School Runner.  Check to see the Sections are set for the synced assessment.



## Impacted Areas in Application

List general components of the application that this PR will affect:
* lib/tasks/sr_export.rake
* Gemfile.d/development.rb

## Mentions @username

Tag users that need to review this code
@RaneClowd 
