### PR TITLE
Puts statement for Section Period IDs

### DIFF
--- a/lib/tasks/sr_export.rake
+++ b/lib/tasks/sr_export.rake
@@ -76,7 +76,7 @@ def quiz_sr_api_data(quiz)
     }.join(',').split(',').map { |section_period|
         section_period.to_i
     }
-
+    puts('SECTION PERIOD IDs: ', section_period_ids.to_s)
     {
         :assessment_definition => {
             :external_assessment_id => 'CANVAS_' + quiz.id.to_s,


### PR DESCRIPTION
While fixing a merge conflict, we decided it would be a good idea to keep the `puts` statement for section period ids in the event we run the sync and see what ids--if any--are being sent to School Runner.  